### PR TITLE
feat: added new arrays in DTO and CC and BCC into sendMessage

### DIFF
--- a/src/Messaging/DTOs/MessageData.php
+++ b/src/Messaging/DTOs/MessageData.php
@@ -9,6 +9,8 @@ class MessageData
         public string $to,        // Destinatário (e-mail ou telefone)
         public string $from,      // Remetente (opcional, depende do provedor)
         public string $content,   // Conteúdo da mensagem
-        public ?array $metadata = [] // Metadados adicionais (headers, configs específicas)
+        public ?array $metadata = [], // Metadados adicionais (headers, configs específicas)
+        public ?array $addCC = [], // Destinatários em cópia visível (e-mail ou telefone)
+        public ?array $addBCC = [] // Destinatários em cópia oculta (e-mail ou telefone)
     ) {}
 }

--- a/src/Messaging/Providers/SendGridProvider.php
+++ b/src/Messaging/Providers/SendGridProvider.php
@@ -40,6 +40,18 @@ class SendGridProvider implements MessagingProviderInterface
             $email->addContent('text/plain', $messageData->content);
             $email->addContent('text/html', "<p>{$messageData->content}</p>");
 
+            if (isset($messageData->addCC)) {
+                foreach ($messageData->addCC as $cc) {
+                    $email->addCc($cc);
+                }
+            }
+
+            if (isset($messageData->addBCC)) {
+                foreach ($messageData->addBCC as $bcc) {
+                    $email->addBcc($bcc);
+                }
+            }
+
             $response = $this->sendGrid->send($email);
 
             return [
@@ -49,6 +61,8 @@ class SendGridProvider implements MessagingProviderInterface
                 'from' => $messageData->from,
                 'type' => 'email',
                 'http_status' => $response->statusCode(),
+                'cc' => $messageData->addCC ?? null,
+                'bcc' => $messageData->addBCC ?? null,
             ];
         } catch (Exception $e) {
             $errorResponse = method_exists($e, 'getResponse') ? $e->getResponse() : null;


### PR DESCRIPTION
Implementado suporte a cópia (CC) e cópia oculta (BCC) no provider de e-mail (SendGrid).
Novos campos aceitos em "MessageData".
Ambos devem ser informados como arrays de e-mails.
Resposta da API agora inclui estes e-mails no payload de retorno.