### PR TITLE
Fix: env() helpers in providers

### DIFF
--- a/src/Messaging/Config/messaging.php
+++ b/src/Messaging/Config/messaging.php
@@ -4,6 +4,8 @@ return [
     'twilio' => [
         'account_sid' => env('TWILIO_ACCOUNT_SID'),
         'auth_token' => env('TWILIO_AUTH_TOKEN'),
+        'sms_from' => env('TWILIO_SMS_FROM'),
+        'whatsapp_from' => env('TWILIO_WHATSAPP_FROM'),
     ],
     'sendgrid' => [
         'api_key' => env('SENDGRID_API_KEY'),

--- a/src/Messaging/Providers/TwilioProvider.php
+++ b/src/Messaging/Providers/TwilioProvider.php
@@ -33,8 +33,8 @@ class TwilioProvider implements MessagingProviderInterface
     {
         try {
             $from = $messageData->type === 'whatsapp'
-                ? 'whatsapp:'.env('TWILIO_WHATSAPP_FROM')
-                : env('TWILIO_SMS_FROM');
+                ? 'whatsapp:'.config('messaging.twilio.whatsapp_from')
+                : config('messaging.twilio.sms_from');
 
             $message = $this->twilio->messages->create(
                 $messageData->type === 'whatsapp' ? 'whatsapp:'.$messageData->to : $messageData->to,


### PR DESCRIPTION
## 📝 Introduction:
Due to no avaiability of `env()` helper in no local environments, it is required to remove that kind of call in files outside `Config/messaging.php`.

## ✨ What's New:
- Config/messaging.php received new fields
- TwillioProvider calling `config()` helper instead of `env()`