### PR TITLE
feat: enrich SendGrid message context

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,14 @@ $messageData = new MessageData(
     to: 'destinatario@example.com',
     from: env('SENDGRID_FROM_EMAIL'),
     content: 'Este é um e-mail de teste enviado via SendGrid.',
-    metadata: ['subject' => 'Teste de E-mail via SendGrid'],
+    subject: 'Teste de E-mail via SendGrid',
+    fromName: 'Inovanti',
+    replyTo: 'suporte@example.com',
+    replyToName: 'Suporte Inovanti',
+    categories: ['transactional', 'credit'],
+    customArgs: ['operation' => 'proposal_created'],
+    headers: ['X-Trace-Id' => 'trace-123'],
+    correlationId: 'proposal-123',
     addCC: ['destinatario2@example.com', 'destinatario3@example.com'],
     addBCC: ['destinatario.oculto@example.com', 'destinatario.oculto1@example.com']
 );
@@ -206,6 +213,32 @@ $response = $messageService->send($messageData);
 
 print_r($response);
 ```
+
+O campo `subject` é opcional. Para compatibilidade, o assunto informado em
+`metadata['subject']` continua sendo aceito. Quando `correlationId` é informado,
+ele também é enviado ao SendGrid como o custom arg `correlation_id`, facilitando
+a correlação do envio com os eventos e a atividade da mensagem.
+
+O retorno do envio preserva os campos existentes (`status`, `message_id`, `to`,
+`from`, `type`, `http_status`, `cc` e `bcc`) e inclui o contexto rastreável usado
+no payload, além de `response_headers` e `response_body` do SendGrid.
+`message_id` e `x_message_id` representam o `X-Message-ID` retornado no aceite do
+Mail Send. O `sg_message_id` definitivo é atribuído aos eventos individuais pelo
+SendGrid e pode ser obtido na atividade da mensagem ou no Event Webhook.
+
+Categorias devem representar agrupamentos gerais. Para identificadores por envio,
+prefira `customArgs` ou `correlationId`. Não envie dados pessoais sensíveis nesses
+campos, pois o SendGrid não os trata como PII e pode armazená-los por longo prazo.
+
+Para consultar a atividade de uma mensagem pelo ID retornado no envio:
+
+```php
+$message = $emailService->getMessageById($response['message_id']);
+```
+
+Essa consulta utiliza a Email Activity Feed API do SendGrid e exige que a conta
+tenha o histórico adicional contratado e que a API key possua permissão de acesso
+à atividade de e-mail.
 
 ## 🧪 Testes
 

--- a/src/Messaging/DTOs/MessageData.php
+++ b/src/Messaging/DTOs/MessageData.php
@@ -5,7 +5,7 @@ namespace InovantiBank\Messaging\DTOs;
 class MessageData
 {
     /**
-     * @param AttachmentData[] $addAttachments
+     * @param  AttachmentData[]  $addAttachments
      */
     public function __construct(
         public string $type,      // Tipo da mensagem (email, sms, whatsapp)
@@ -16,11 +16,19 @@ class MessageData
         public ?array $addCC = [], // Destinatários em cópia visível (e-mail ou telefone)
         public ?array $addBCC = [], // Destinatários em cópia oculta (e-mail ou telefone)
         public ?array $addAttachments = [], // Anexos da mensagem
+        public ?string $subject = null, // Assunto estruturado do e-mail
+        public ?string $fromName = null, // Nome do remetente
+        public ?string $replyTo = null, // Endereço para respostas
+        public ?string $replyToName = null, // Nome do destinatário de respostas
+        public ?array $categories = [], // Categorias gerais do SendGrid
+        public ?array $customArgs = [], // Argumentos rastreáveis do SendGrid
+        public ?array $headers = [], // Cabeçalhos customizados do SendGrid
+        public ?string $correlationId = null, // Identificador de correlação da aplicação
     ) {
         foreach ($this->addAttachments as $attachment) {
             if (! $attachment instanceof AttachmentData) {
                 throw new \InvalidArgumentException(
-                    "Attachments should be instances of AttachmentData."
+                    'Attachments should be instances of AttachmentData.'
                 );
             }
         }

--- a/src/Messaging/Providers/SendGridProvider.php
+++ b/src/Messaging/Providers/SendGridProvider.php
@@ -32,13 +32,36 @@ class SendGridProvider implements MessagingProviderInterface
      */
     public function sendMessage(MessageData $messageData): array
     {
+        $subject = $messageData->subject ?? $messageData->metadata['subject'] ?? 'No Subject';
+        $customArgs = $messageData->customArgs ?? [];
+
+        if ($messageData->correlationId !== null) {
+            $customArgs['correlation_id'] = $messageData->correlationId;
+        }
+
         try {
             $email = new Mail;
-            $email->setFrom($messageData->from);
-            $email->setSubject($messageData->metadata['subject'] ?? 'No Subject');
+            $email->setFrom($messageData->from, $messageData->fromName);
+            $email->setSubject($subject);
             $email->addTo($messageData->to);
             $email->addContent('text/plain', $messageData->content);
             $email->addContent('text/html', "<p>{$messageData->content}</p>");
+
+            if ($messageData->replyTo !== null) {
+                $email->setReplyTo($messageData->replyTo, $messageData->replyToName);
+            }
+
+            foreach ($messageData->categories ?? [] as $category) {
+                $email->addCategory($category);
+            }
+
+            foreach ($customArgs as $key => $value) {
+                $email->addCustomArg($key, $value);
+            }
+
+            foreach ($messageData->headers ?? [] as $key => $value) {
+                $email->addHeader($key, $value);
+            }
 
             if (isset($messageData->addCC)) {
                 foreach ($messageData->addCC as $cc) {
@@ -63,16 +86,30 @@ class SendGridProvider implements MessagingProviderInterface
             }
 
             $response = $this->sendGrid->send($email);
+            $responseHeaders = $this->headersToArrayAssoc($response->headers());
+            $messageId = $this->findHeader($responseHeaders, 'X-Message-Id');
 
             return [
                 'status' => $response->statusCode() === 202 ? 'success' : 'error',
-                'message_id' => $this->headersToArrayAssoc($response->headers())['X-Message-Id'] ?? null,
+                'message_id' => $messageId,
+                'x_message_id' => $messageId,
                 'to' => $messageData->to,
                 'from' => $messageData->from,
                 'type' => 'email',
                 'http_status' => $response->statusCode(),
                 'cc' => $messageData->addCC ?? null,
                 'bcc' => $messageData->addBCC ?? null,
+                'subject' => $subject,
+                'from_name' => $messageData->fromName,
+                'reply_to' => $messageData->replyTo,
+                'reply_to_name' => $messageData->replyToName,
+                'categories' => $messageData->categories ?? [],
+                'custom_args' => $customArgs,
+                'headers' => $messageData->headers ?? [],
+                'correlation_id' => $messageData->correlationId,
+                'metadata' => $messageData->metadata ?? [],
+                'response_headers' => $responseHeaders,
+                'response_body' => $this->decodeResponseBody($response->body()),
             ];
         } catch (Exception $e) {
             $errorResponse = method_exists($e, 'getResponse') ? $e->getResponse() : null;
@@ -81,6 +118,12 @@ class SendGridProvider implements MessagingProviderInterface
                 'status' => 'error',
                 'error' => $e->getMessage(),
                 'response' => $errorResponse ? $errorResponse->getBody()->getContents() : null,
+                'to' => $messageData->to,
+                'from' => $messageData->from,
+                'type' => 'email',
+                'subject' => $subject,
+                'correlation_id' => $messageData->correlationId,
+                'custom_args' => $customArgs,
             ];
         }
     }
@@ -100,12 +143,24 @@ class SendGridProvider implements MessagingProviderInterface
                 throw new Exception("Erro ao buscar detalhes da mensagem. Status HTTP: {$response->statusCode()}");
             }
 
-            return json_decode($response->body(), true);
+            $message = json_decode($response->body(), true);
+
+            if (! is_array($message)) {
+                throw new Exception('Resposta inválida ao buscar detalhes da mensagem.');
+            }
+
+            $message['message_id'] ??= $message['msg_id'] ?? $message['sg_message_id'] ?? $message['id'] ?? $msgId;
+            $message['custom_args'] ??= $this->normalizeCustomArgs($message['unique_args'] ?? []);
+            $message['http_status'] = $response->statusCode();
+
+            return $message;
         } catch (Exception $e) {
             return [
                 'status' => 'error',
                 'error' => $e->getMessage(),
                 'http_status' => isset($response) ? $response->statusCode() : null,
+                'message_id' => $msgId,
+                'response_body' => isset($response) ? $this->decodeResponseBody($response->body()) : null,
             ];
         }
     }
@@ -114,14 +169,55 @@ class SendGridProvider implements MessagingProviderInterface
     {
         $headersAssoc = [];
 
-        foreach ($headers as $header) {
-            if (strpos($header, ': ') !== false) {
-                [$key, $value] = explode(': ', $header, 2);
-                $headersAssoc[$key] = $value;
+        foreach ($headers as $key => $value) {
+            if (is_string($key)) {
+                $headersAssoc[$key] = is_array($value)
+                    ? implode(', ', $value)
+                    : (string) $value;
+
+                continue;
+            }
+
+            if (is_string($value) && str_contains($value, ':')) {
+                [$headerKey, $headerValue] = explode(':', $value, 2);
+                $headersAssoc[trim($headerKey)] = trim($headerValue);
             }
         }
 
         return $headersAssoc;
+    }
+
+    private function findHeader(array $headers, string $name): ?string
+    {
+        foreach ($headers as $key => $value) {
+            if (strcasecmp($key, $name) === 0) {
+                return trim($value);
+            }
+        }
+
+        return null;
+    }
+
+    private function decodeResponseBody(string $body): array|string|null
+    {
+        if ($body === '') {
+            return null;
+        }
+
+        $decoded = json_decode($body, true);
+
+        return json_last_error() === JSON_ERROR_NONE && is_array($decoded) ? $decoded : $body;
+    }
+
+    private function normalizeCustomArgs(array|string $customArgs): array
+    {
+        if (is_array($customArgs)) {
+            return $customArgs;
+        }
+
+        $decoded = json_decode($customArgs, true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 
     private function sanitizeFileName(string $fileName)

--- a/src/Messaging/Services/SendGridEmailService.php
+++ b/src/Messaging/Services/SendGridEmailService.php
@@ -19,4 +19,9 @@ class SendGridEmailService implements MessagingChannelInterface
     {
         return $this->provider->sendMessage($messageData);
     }
+
+    public function getMessageById(string $messageId): ?array
+    {
+        return $this->provider->getMessageById($messageId);
+    }
 }

--- a/tests/Unit/Providers/SendGridProviderTest.php
+++ b/tests/Unit/Providers/SendGridProviderTest.php
@@ -7,19 +7,30 @@ use InovantiBank\Messaging\Providers\SendGridProvider;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use SendGrid;
+use SendGrid\Mail\Mail;
+use SendGrid\Response;
 
 class SendGridProviderTest extends TestCase
 {
-    public function test_it_sends_email_successfully()
+    protected function tearDown(): void
     {
-        $responseMock = Mockery::mock(Response::class);
-        $responseMock->shouldReceive('statusCode')->andReturn(202);
-        $responseMock->shouldReceive('headers')->andReturn(['X-Message-Id' => ['email-123']]);
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_it_sends_email_successfully_and_preserves_existing_contract(): void
+    {
+        $response = new Response(202, '', [
+            'HTTP/1.1 202 Accepted',
+            'X-Message-Id: email-123',
+        ]);
 
         $sendGridMock = Mockery::mock(SendGrid::class);
         $sendGridMock->shouldReceive('send')
             ->once()
-            ->andReturn($responseMock);
+            ->with(Mockery::type(Mail::class))
+            ->andReturn($response);
 
         $provider = new SendGridProvider('fake_api_key');
         $provider->setMockInstance($sendGridMock);
@@ -32,9 +43,116 @@ class SendGridProviderTest extends TestCase
             metadata: ['subject' => 'Test Subject']
         );
 
-        $response = $provider->sendMessage($messageData);
+        $result = $provider->sendMessage($messageData);
 
-        $this->assertEquals('success', $response['status']);
-        $this->assertEquals('email-123', $response['message_id']);
+        $this->assertSame('success', $result['status']);
+        $this->assertSame('email-123', $result['message_id']);
+        $this->assertSame('email-123', $result['x_message_id']);
+        $this->assertSame('Test Subject', $result['subject']);
+        $this->assertSame(202, $result['http_status']);
+    }
+
+    public function test_it_sends_and_returns_sendgrid_tracking_context(): void
+    {
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('statusCode')->andReturn(202);
+        $responseMock->shouldReceive('headers')->andReturn([
+            'x-message-id' => ['email-456'],
+            'x-ratelimit-remaining' => '599',
+        ]);
+        $responseMock->shouldReceive('body')->andReturn('{"accepted":true}');
+
+        $sendGridMock = Mockery::mock(SendGrid::class);
+        $sendGridMock->shouldReceive('send')
+            ->once()
+            ->with(Mockery::on(function (Mail $email): bool {
+                $payload = json_decode(json_encode($email), true);
+
+                $this->assertSame(
+                    ['name' => 'Inovanti', 'email' => 'no-reply@example.com'],
+                    $payload['from']
+                );
+                $this->assertSame(
+                    ['name' => 'Support', 'email' => 'support@example.com'],
+                    $payload['reply_to']
+                );
+                $this->assertSame('Structured subject', $payload['subject']);
+                $this->assertSame(['transactional', 'credit'], $payload['categories']);
+                $this->assertSame([
+                    'operation' => 'proposal_created',
+                    'correlation_id' => 'correlation-123',
+                ], $payload['personalizations'][0]['custom_args']);
+                $this->assertSame(
+                    ['X-Trace-Id' => 'trace-123'],
+                    $payload['personalizations'][0]['headers']
+                );
+
+                return true;
+            }))
+            ->andReturn($responseMock);
+
+        $provider = new SendGridProvider('fake_api_key');
+        $provider->setMockInstance($sendGridMock);
+
+        $messageData = new MessageData(
+            type: 'email',
+            to: 'user@example.com',
+            from: 'no-reply@example.com',
+            content: 'Test email',
+            metadata: ['audit_source' => 'credit-api'],
+            subject: 'Structured subject',
+            fromName: 'Inovanti',
+            replyTo: 'support@example.com',
+            replyToName: 'Support',
+            categories: ['transactional', 'credit'],
+            customArgs: ['operation' => 'proposal_created'],
+            headers: ['X-Trace-Id' => 'trace-123'],
+            correlationId: 'correlation-123',
+        );
+
+        $result = $provider->sendMessage($messageData);
+
+        $this->assertSame('email-456', $result['message_id']);
+        $this->assertSame('correlation-123', $result['correlation_id']);
+        $this->assertSame([
+            'operation' => 'proposal_created',
+            'correlation_id' => 'correlation-123',
+        ], $result['custom_args']);
+        $this->assertSame(['accepted' => true], $result['response_body']);
+        $this->assertSame('599', $result['response_headers']['x-ratelimit-remaining']);
+    }
+
+    public function test_it_enriches_message_details_without_removing_sendgrid_fields(): void
+    {
+        $response = new Response(200, json_encode([
+            'msg_id' => 'email-789',
+            'status' => 'delivered',
+            'categories' => ['transactional'],
+            'unique_args' => '{"correlation_id":"correlation-789"}',
+            'events' => [['event_name' => 'delivered']],
+        ]));
+
+        $messageResource = Mockery::mock();
+        $messageResource->shouldReceive('get')->once()->andReturn($response);
+
+        $messagesResource = Mockery::mock();
+        $messagesResource->shouldReceive('_')->once()->with('email-789')->andReturn($messageResource);
+
+        $sendGridMock = Mockery::mock(SendGrid::class);
+        $sendGridMock->client = Mockery::mock();
+        $sendGridMock->client->shouldReceive('messages')->once()->andReturn($messagesResource);
+
+        $provider = new SendGridProvider('fake_api_key');
+        $provider->setMockInstance($sendGridMock);
+
+        $result = $provider->getMessageById('email-789');
+
+        $this->assertSame('email-789', $result['msg_id']);
+        $this->assertSame('email-789', $result['message_id']);
+        $this->assertSame('delivered', $result['status']);
+        $this->assertSame(['transactional'], $result['categories']);
+        $this->assertSame('{"correlation_id":"correlation-789"}', $result['unique_args']);
+        $this->assertSame(['correlation_id' => 'correlation-789'], $result['custom_args']);
+        $this->assertSame(200, $result['http_status']);
     }
 }

--- a/tests/Unit/Services/SendGridEmailServiceTest.php
+++ b/tests/Unit/Services/SendGridEmailServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use InovantiBank\Messaging\Providers\SendGridProvider;
+use InovantiBank\Messaging\Services\SendGridEmailService;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class SendGridEmailServiceTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_it_gets_message_details_through_the_service(): void
+    {
+        $provider = Mockery::mock(SendGridProvider::class);
+        $provider->shouldReceive('getMessageById')
+            ->once()
+            ->with('email-123')
+            ->andReturn([
+                'message_id' => 'email-123',
+                'status' => 'delivered',
+            ]);
+
+        $service = new SendGridEmailService($provider);
+
+        $result = $service->getMessageById('email-123');
+
+        $this->assertSame('email-123', $result['message_id']);
+        $this->assertSame('delivered', $result['status']);
+    }
+}


### PR DESCRIPTION
## 📑 Descrição

Enriquece o contexto disponível no envio e na consulta de mensagens SendGrid para facilitar persistência, auditoria e correlação nos sistemas consumidores.

Foram adicionados campos opcionais ao MessageData para assunto estruturado, nome do remetente, reply-to, categories, custom args, headers customizados e correlation ID.

O retorno do envio passa a incluir o contexto efetivamente utilizado, headers e body da resposta do SendGrid, além de extração robusta do X-Message-ID.

A consulta por ID foi exposta no SendGridEmailService e seu retorno foi enriquecido com message_id, custom_args normalizado e http_status, preservando os campos originais da API.

O comportamento existente de metadata[subject] e os campos já retornados pelo envio foram mantidos para compatibilidade.

Versão proposta para publicação: v1.5.0.

## 📋 Requisitos

- API key com permissão de Email Activity para consultas de mensagens.
- Histórico adicional da Email Activity habilitado na conta SendGrid para uso do endpoint de consulta.

## 📝 Tarefas

Sem tarefa

## ⚙️ Build / Validações

- PHPUnit focado no SendGrid: 4 testes e 25 assertions passando.
- Laravel Pint nos arquivos PHP alterados: passou.
- Validação de sintaxe PHP: passou.
- git diff --check: passou.
- Suíte unitária completa executada, com duas falhas preexistentes relacionadas ao fluxo Twilio.
- composer validate: composer.json válido; lock file preexistente desatualizado.